### PR TITLE
fixed gun/key dupe bug

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -140,6 +140,7 @@ public class Inventory : MonoBehaviour
         if (!itemSlots[index].IsEmpty())
         {
             currentHeldItem = Instantiate(itemSlots[index].itemData.worldPrefab, rightHoldPosition);
+            currentHeldItem.tag = "Untagged";
             if (currentHeldItem.name == "Pistol(Clone)" && isGuard)
             {
                 Gun GunScript = currentHeldItem.GetComponent<Gun>();


### PR DESCRIPTION
Just a simple approach one-line fix that prevent guards from duping items by "picking up" items held by themselves or by other guards